### PR TITLE
Fix Docker build dependency install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Install dependencies only when needed
 FROM node:18-alpine AS deps
 
-ENV NODE_ENV=production
-
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat g++ make py3-pip
 
@@ -10,7 +8,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 RUN yarn config set network-timeout 600000 -g
-RUN yarn install --frozen-lockfile 
+RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM node:18-alpine AS builder


### PR DESCRIPTION
## Summary
- remove NODE_ENV=production from the Docker deps stage so Yarn installs the normal dependency set consistently
- keeps NODE_ENV=production in the builder/runner stages for production build/runtime behavior
- cleans up Dockerfile formatting/newline noise

## Validation
- NODE_ENV=production npx --yes yarn@1.22.19 build

## Notes
- Docker is not installed on this runner, so I could not run a full docker build locally.